### PR TITLE
fix boost deprecation

### DIFF
--- a/ros/src/fiducials.cpp
+++ b/ros/src/fiducials.cpp
@@ -91,7 +91,7 @@
 #include <cob_fiducials/aruco/FiducialModelAruco.h>
 
 #include <boost/thread/mutex.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <opencv2/opencv.hpp>
 


### PR DESCRIPTION
fixes 
```
Warnings   << cob_fiducials:make /home/fxm/projects/default/mojin_ws/logs/cob_fiducials/build.make.000.log                                                                                                                                              
In file included from /usr/include/boost/config/header_deprecated.hpp:18,
                 from /usr/include/boost/timer.hpp:20,
                 from /home/fxm/projects/default/mojin_ws/src/cob_fiducials/ros/src/fiducials.cpp:94:
/usr/include/boost/timer.hpp:21:1: note: #pragma message: This header is deprecated. Use the facilities in <boost/timer/timer.hpp> instead.
   21 | BOOST_HEADER_DEPRECATED( "the facilities in <boost/timer/timer.hpp>" )
      | ^~~~~~~~~~~~~~~~~~~~~~~
cd /home/fxm/projects/default/mojin_ws/build/cob_fiducials; catkin build --get-env cob_fiducials | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd
```